### PR TITLE
fix command to delete bridge in FAQ

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -5,7 +5,7 @@
 
    Run the following to delete bridge `foo`:
    ```bash
-   $ sudo ovs-vsctl foo
+   $ sudo ovs-vsctl del-br foo
    ```
  - "Error creating link `foo`: RTNETLINK answers: File exists"
 


### PR DESCRIPTION
Took me a while to figure this one out, but the command to delete a bridge needs to include `del-br`.